### PR TITLE
node version 16 as prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This Substrate Engine for Artillery makes it easy to script virtual user flows i
 ## How to use
 
 ### Prerequisites
-- node.js version > 14
+- node.js version > 16
 - npm > 6
 
 ### Installation:


### PR DESCRIPTION
Should this be 16 since the tests uses 16? Maybe even `==` instead of `>` ?